### PR TITLE
Remove OpenMP dependency

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -10,78 +10,25 @@ jobs:
         - platform: x64
           bcj: -mf=BCJ2
           name: x64
-          toolset: ClangCL
-          ompdll: libomp.dll
         - platform: Win32
           bcj: -mf=BCJ2
           name: x86
-          toolset: ClangCL
-          ompdll: libomp.dll
         - platform: ARM64
           bcj: # -mf=ARM64
           name: arm64
-          toolset: v142
-          ompdll: vcomp140.dll
     name: Build ${{ matrix.name }} Windows binary
     runs-on: windows-2019
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: actions/checkout@v3
-      - run: msbuild -property:PlatformToolset=${{ matrix.toolset }} -property:Configuration=Release -property:Platform=${{ matrix.platform }} par2cmdline.sln
-      - run: move "${{ matrix.platform }}\Release\par2.exe" par2.exe && move "${{ matrix.platform }}\Release\${{ matrix.ompdll }}" ${{ matrix.ompdll }} && 7z a -t7z -mx=9 ${{ matrix.bcj }} par2.7z par2.exe ${{ matrix.ompdll }}
+      - run: msbuild -property:PlatformToolset=ClangCL -property:Configuration=Release -property:Platform=${{ matrix.platform }} par2cmdline.sln
+      - run: move "${{ matrix.platform }}\Release\par2.exe" par2.exe && 7z a -t7z -mx=9 ${{ matrix.bcj }} par2.7z par2.exe
       - uses: actions/upload-artifact@v3
         with:
           path: ./par2.7z
           name: par2cmdline-turbo-dev-win-${{ matrix.name }}.7z
           retention-days: 5
   
-#  build-dev-linux-static:
-#    strategy:
-#      matrix:
-#        include:
-#        - target: x86_64-linux-musl
-#          xz_bcj: --x86
-#          name: amd64
-#          configure_host: 
-#        - target: aarch64-linux-musl
-#          xz_bcj: # --arm64 # requires xz utils >=5.4 to decompress
-#          name: aarch64
-#          configure_host: --host=aarch64
-#        - target: armv7l-linux-musleabihf
-#          xz_bcj: --arm
-#          name: armv7l
-#          configure_host: --host=armv7l
-#    name: Build ${{ matrix.name }} Linux static binary
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: Lesmiscore/musl-cross-compilers@heracles
-#        id: musl
-#        with:
-#          target: ${{ matrix.target }}
-#      - run: aclocal && automake --warnings=all --add-missing && autoconf --warnings=all
-#      - run: ./configure --enable-openmp ${{ matrix.configure_host }}
-#        env:
-#          CC: ${{ steps.musl.outputs.path }}/${{ matrix.target }}-cc
-#          CXX: ${{ steps.musl.outputs.path }}/${{ matrix.target }}-c++
-#          LDFLAGS: -static
-#      - uses: actions/upload-artifact@v3
-#        with:
-#          path: ./config.log
-#          name: configure-linux-${{ matrix.arch }}.log
-#          retention-days: 5
-#        if: ${{ failure() }}
-#      - run: make
-#      - run: ./par2 -h
-#        if: ${{ matrix.name == 'amd64' }}
-#      - run: make check
-#        if: ${{ matrix.name == 'amd64' }}
-#      - run: xz -9e ${{ matrix.xz_bcj }} --lzma2 par2 -c > par2.xz
-#      - uses: actions/upload-artifact@v3
-#        with:
-#          path: ./par2.xz
-#          name: par2cmdline-turbo-dev-linux-${{ matrix.name }}.xz
-#          retention-days: 5
   build-dev-linux-static:
     strategy:
       matrix:
@@ -107,7 +54,7 @@ jobs:
           arch: ${{ matrix.arch }}
         if: ${{ matrix.arch != 'amd64' }}
       - run: aclocal && automake --warnings=all --add-missing && autoconf --warnings=all
-      - run: ./configure --enable-openmp ${{ matrix.configure_host }}
+      - run: ./configure ${{ matrix.configure_host }}
         env:
           CC: ${{ matrix.xcc }}gcc
           CXX: ${{ matrix.xcc }}g++
@@ -136,20 +83,15 @@ jobs:
     steps:
       - uses: ConorMacBride/install-package@v1
         with:
-          brew: automake libomp llvm
+          brew: automake llvm
       - run: |
           if [ -f "`brew --prefix llvm`/bin/clang" ]; then
             echo "CC=`brew --prefix llvm`/bin/clang" >> $GITHUB_ENV
             echo "CXX=`brew --prefix llvm`/bin/clang++" >> $GITHUB_ENV
           fi
-          if [ -d "`brew --prefix llvm`/lib" ]; then
-            echo "LIBOMP_PATH=`brew --prefix llvm`/lib" >> $GITHUB_ENV
-          else
-            echo "LIBOMP_PATH=/usr/local/opt/libomp/lib" >> $GITHUB_ENV
-          fi
       - uses: actions/checkout@v3
       - run: aclocal && automake --warnings=all --add-missing && autoconf --warnings=all
-      - run: ./configure --enable-openmp
+      - run: ./configure
       - uses: actions/upload-artifact@v3
         with:
           path: ./config.log
@@ -157,29 +99,13 @@ jobs:
           retention-days: 5
         if: ${{ failure() }}
       - run: make
-      - run: |
-          cp $LIBOMP_PATH/libomp.dylib .
-          chmod 0644 libomp.dylib
-          LC_RPATH="$(otool -l par2 | grep -A2 LC_RPATH | tail -n1 | sed 's/^ *path //' | sed 's/ (offset .*)$//')"
-          if [ -z "$LC_RPATH" ]; then
-            install_name_tool -change $LIBOMP_PATH/libomp.dylib @rpath/libomp.dylib -add_rpath @executable_path par2
-          else
-            install_name_tool -change $LIBOMP_PATH/libomp.dylib @rpath/libomp.dylib -rpath "$LC_RPATH" @executable_path par2
-          fi
-      - if: ${{ failure() }}
-        run: |
-          otool -L par2
-          otool -l par2
-          echo "$(otool -l par2 | grep -A2 LC_RPATH | tail -n1 | sed 's/^ *path //' | sed 's/ (offset .*)$//')"
       - run: ./par2 -h
       - run: make check
-      - run: tar -Jcf par2.txz par2 libomp.dylib
-        env:
-          XZ_OPT: -9e --x86 --lzma2
+      - run: xz -9e --x86 --lzma2 par2
       - uses: actions/upload-artifact@v3
         with:
-          path: ./par2.txz
-          name: par2cmdline-turbo-dev-macos-x64.txz
+          path: ./par2.xz
+          name: par2cmdline-turbo-dev-macos-x64.xz
           retention-days: 5
 
   build-dev-mac-arm64:
@@ -190,20 +116,9 @@ jobs:
       - uses: mbround18/setup-osxcross@main  # OSXCROSS_TARGET unavailable in v1.1
         with:
           osx-version: "12.3"
-      - run: osxcross-macports install -arm64 libomp
-        env:
-          MACOSX_DEPLOYMENT_TARGET: "12.3"
-          UNATTENDED: 1
-      - run: |
-          if [ ! -d "$OSXCROSS_TARGET/macports/pkgs/opt/local" ]; then
-            echo "Error! Failed to find ${OSXCROSS_TARGET}/macports/pkgs/opt/local folder!"
-            exit 1
-          fi
-          echo "LIBRARY_PATH=$OSXCROSS_TARGET/macports/pkgs/opt/local/lib/libomp" >> $GITHUB_ENV
-          echo "CPATH=$OSXCROSS_TARGET/macports/pkgs/opt/local/include/libomp" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - run: aclocal && automake --warnings=all --add-missing && autoconf --warnings=all
-      - run: ./configure --enable-openmp --host=aarch64-macos
+      - run: ./configure --host=aarch64-macos
         env:
           CC: oa64-clang
           CXX: oa64-clang++
@@ -218,20 +133,6 @@ jobs:
         if: ${{ failure() }}
       - run: make
       - run: |
-          cp $LIBRARY_PATH/libomp.dylib .
-          chmod 0644 libomp.dylib
-          LC_RPATH="$(arm64-apple-darwin21.4-otool -l par2 | grep -A2 LC_RPATH | tail -n1 | sed 's/^ *path //' | sed 's/ (offset .*)$//')"
-          if [ -z "$LC_RPATH" ]; then
-            arm64-apple-darwin21.4-install_name_tool -change /opt/local/lib/libomp/libomp.dylib @rpath/libomp.dylib -add_rpath @executable_path par2
-          else
-            arm64-apple-darwin21.4-install_name_tool -change /opt/local/lib/libomp/libomp.dylib @rpath/libomp.dylib -rpath "$LC_RPATH" @executable_path par2
-          fi
-      - if: ${{ failure() }}
-        run: |
-          arm64-apple-darwin21.4-otool -L par2
-          arm64-apple-darwin21.4-otool -l par2
-          echo "$(arm64-apple-darwin21.4-otool -l par2 | grep -A2 LC_RPATH | tail -n1 | sed 's/^ *path //' | sed 's/ (offset .*)$//')"
-      - run: |
           wget -q -O- https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F0.22.0/apple-codesign-0.22.0-x86_64-unknown-linux-musl.tar.gz | tar zxf -
           apple-codesign*/rcodesign sign par2
       - if: ${{ failure() }}
@@ -239,11 +140,9 @@ jobs:
           ls
           ls apple-codesign*
           find . -name rcodesign
-      - run: tar --group=nobody --owner=nobody -Jcf par2.txz par2 libomp.dylib
-        env:
-          XZ_OPT: -9e --lzma2
+      - run: xz -9e --lzma2 par2
       - uses: actions/upload-artifact@v3
         with:
-          path: ./par2.txz
-          name: par2cmdline-turbo-dev-macos-arm64.txz
+          path: ./par2.xz
+          name: par2cmdline-turbo-dev-macos-arm64.xz
           retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,18 +14,12 @@ jobs:
         - platform: x64
           bcj: -mf=BCJ2
           name: x64
-          toolset: ClangCL
-          ompdll: libomp.dll
         - platform: Win32
           bcj: -mf=BCJ2
           name: x86
-          toolset: ClangCL
-          ompdll: libomp.dll
         - platform: ARM64
           bcj: # -mf=ARM64
           name: arm64
-          toolset: v142
-          ompdll: vcomp140.dll
     name: Build ${{ matrix.name }} Windows binary
     runs-on: windows-2019
     steps:
@@ -36,8 +30,8 @@ jobs:
         uses: bruceadams/get-release@v1.2.3
         env:
           GITHUB_TOKEN: ${{ github.token }}
-      - run: msbuild -property:PlatformToolset=${{ matrix.toolset }} -property:Configuration=Release -property:Platform=${{ matrix.platform }} par2cmdline.sln
-      - run: move "${{ matrix.platform }}\Release\par2.exe" par2.exe && move "${{ matrix.platform }}\Release\${{ matrix.ompdll }}" ${{ matrix.ompdll }} && 7z a -t7z -mx=9 ${{ matrix.bcj }} par2.7z par2.exe ${{ matrix.ompdll }}
+      - run: msbuild -property:PlatformToolset=ClangCL -property:Configuration=Release -property:Platform=${{ matrix.platform }} par2cmdline.sln
+      - run: move "${{ matrix.platform }}\Release\par2.exe" par2.exe && 7z a -t7z -mx=9 ${{ matrix.bcj }} par2.7z par2.exe
       - uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -77,7 +71,7 @@ jobs:
           arch: ${{ matrix.arch }}
         if: ${{ matrix.arch != 'amd64' }}
       - run: aclocal && automake --warnings=all --add-missing && autoconf --warnings=all
-      - run: ./configure --enable-openmp ${{ matrix.configure_host }}
+      - run: ./configure ${{ matrix.configure_host }}
         env:
           CC: ${{ matrix.xcc }}gcc
           CXX: ${{ matrix.xcc }}g++
@@ -103,16 +97,11 @@ jobs:
     steps:
       - uses: ConorMacBride/install-package@v1
         with:
-          brew: automake libomp llvm
+          brew: automake llvm
       - run: |
           if [ -f "`brew --prefix llvm`/bin/clang" ]; then
             echo "CC=`brew --prefix llvm`/bin/clang" >> $GITHUB_ENV
             echo "CXX=`brew --prefix llvm`/bin/clang++" >> $GITHUB_ENV
-          fi
-          if [ -d "`brew --prefix llvm`/lib" ]; then
-            echo "LIBOMP_PATH=`brew --prefix llvm`/lib" >> $GITHUB_ENV
-          else
-            echo "LIBOMP_PATH=/usr/local/opt/libomp/lib" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v3
       - name: Get release
@@ -121,29 +110,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - run: aclocal && automake --warnings=all --add-missing && autoconf --warnings=all
-      - run: ./configure --enable-openmp
+      - run: ./configure
       - run: make
-      - run: |
-          cp $LIBOMP_PATH/libomp.dylib .
-          chmod 0644 libomp.dylib
-          LC_RPATH="$(otool -l par2 | grep -A2 LC_RPATH | tail -n1 | sed 's/^ *path //' | sed 's/ (offset .*)$//')"
-          if [ -z "$LC_RPATH" ]; then
-            install_name_tool -change $LIBOMP_PATH/libomp.dylib @rpath/libomp.dylib -add_rpath @executable_path par2
-          else
-            install_name_tool -change $LIBOMP_PATH/libomp.dylib @rpath/libomp.dylib -rpath "$LC_RPATH" @executable_path par2
-          fi
       - run: ./par2 -h
       - run: make check
-      - run: tar -Jcf par2.txz par2 libomp.dylib
-        env:
-          XZ_OPT: -9e --x86 --lzma2
+      - run: xz -9e --x86 --lzma2 par2
       - uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }} 
-          asset_path: ./par2.txz
-          asset_name: par2cmdline-turbo-${{ steps.get_release.outputs.tag_name }}-macos-x64.tar.xz
+          asset_path: ./par2.xz
+          asset_name: par2cmdline-turbo-${{ steps.get_release.outputs.tag_name }}-macos-x64.xz
           asset_content_type: application/octet-stream
 
   build-mac-arm64:
@@ -154,17 +132,6 @@ jobs:
       - uses: mbround18/setup-osxcross@main  # OSXCROSS_TARGET unavailable in v1.1
         with:
           osx-version: "12.3"
-      - run: osxcross-macports install -arm64 libomp
-        env:
-          MACOSX_DEPLOYMENT_TARGET: "12.3"
-          UNATTENDED: 1
-      - run: |
-          if [ ! -d "$OSXCROSS_TARGET/macports/pkgs/opt/local" ]; then
-            echo "Error! Failed to find ${OSXCROSS_TARGET}/macports/pkgs/opt/local folder!"
-            exit 1
-          fi
-          echo "LIBRARY_PATH=$OSXCROSS_TARGET/macports/pkgs/opt/local/lib/libomp" >> $GITHUB_ENV
-          echo "CPATH=$OSXCROSS_TARGET/macports/pkgs/opt/local/include/libomp" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Get release
         id: get_release
@@ -172,7 +139,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - run: aclocal && automake --warnings=all --add-missing && autoconf --warnings=all
-      - run: ./configure --enable-openmp --host=aarch64-macos
+      - run: ./configure --host=aarch64-macos
         env:
           CC: oa64-clang
           CXX: oa64-clang++
@@ -181,25 +148,14 @@ jobs:
           STRIP: arm64-apple-darwin21.4-strip
       - run: make
       - run: |
-          cp $LIBRARY_PATH/libomp.dylib .
-          chmod 0644 libomp.dylib
-          LC_RPATH="$(arm64-apple-darwin21.4-otool -l par2 | grep -A2 LC_RPATH | tail -n1 | sed 's/^ *path //' | sed 's/ (offset .*)$//')"
-          if [ -z "$LC_RPATH" ]; then
-            arm64-apple-darwin21.4-install_name_tool -change /opt/local/lib/libomp/libomp.dylib @rpath/libomp.dylib -add_rpath @executable_path par2
-          else
-            arm64-apple-darwin21.4-install_name_tool -change /opt/local/lib/libomp/libomp.dylib @rpath/libomp.dylib -rpath "$LC_RPATH" @executable_path par2
-          fi
-      - run: |
           wget -q -O- https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F0.22.0/apple-codesign-0.22.0-x86_64-unknown-linux-musl.tar.gz | tar zxf -
           apple-codesign*/rcodesign sign par2
-      - run: tar --group=nobody --owner=nobody -Jcf par2.txz par2 libomp.dylib
-        env:
-          XZ_OPT: -9e --lzma2
+      - run: xz -9e --lzma2 par2
       - uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }} 
-          asset_path: ./par2.txz
-          asset_name: par2cmdline-turbo-${{ steps.get_release.outputs.tag_name }}-macos-arm64.tar.xz
+          asset_path: ./par2.xz
+          asset_name: par2cmdline-turbo-${{ steps.get_release.outputs.tag_name }}-macos-arm64.xz
           asset_content_type: application/octet-stream

--- a/Makefile.am
+++ b/Makefile.am
@@ -187,8 +187,8 @@ par2_SOURCES = src/par2cmdline.cpp \
 	src/commandline.cpp src/commandline.h
 par2_LDADD = libpar2.a
 
-LDADD = -lstdc++
-AM_CXXFLAGS = -Wall -std=c++11 $(OPENMP_CXXFLAGS)
+LDADD = -lstdc++ $(PTHREAD_LIBS)
+AM_CXXFLAGS = -Wall -std=c++11 $(PTHREAD_CFLAGS)
 
 EXTRA_DIST = PORTING ROADMAP \
 			 man/par2.1 \

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This fork is also *not* aimed at fixing bugs or functionality improvements - rep
 
 ## Threading & OpenMP
 
-par2cmdline uses OpenMP to manage threading. ParPar’s GF16 backend has its own threading support, using C++11’s `std::thread`, which means that threading will generally be available even if OpenMP is enabled. However, par2cmdline does use OpenMP in a number of other places (such as file processing), which are still present in this fork.
+par2cmdline-turbo removes par2cmdline's OpenMP dependency, replacing it with C++11's threads.
 
-This does have a flow on effect that the `-t` flag and libpar2’s *threads* parameter will be present and work, even if OpenMP is not enabled.
+This does have a flow on effect that the `-t`/`-T` flags and libpar2’s *threads* related parameters will be present and work, regardless of OpenMP presence (in par2cmdline, these would differ depending on whether OpenMP support was compiled in).
 
 ## Compared to other par2cmdline forks
 

--- a/configure.ac
+++ b/configure.ac
@@ -60,8 +60,9 @@ AC_C_INLINE
 AC_SYS_LARGEFILE
 AC_FUNC_FSEEKO
 
-dnl Check for OpenMP
-AC_OPENMP
+dnl Check for pthreads
+m4_include([m4/acx_pthread.m4])
+ACX_PTHREAD
 
 dnl Checks for library functions.
 AC_FUNC_MEMCMP

--- a/m4/acx_pthread.m4
+++ b/m4/acx_pthread.m4
@@ -1,0 +1,227 @@
+dnl PGSGL:  When updating, comment out port-specific part below;
+dnl see the comment below with the word "PostgreSQL".
+dnl
+dnl Available from the GNU Autoconf Macro Archive at:
+dnl http://www.gnu.org/software/ac-archive/htmldoc/acx_pthread.html
+dnl
+AC_DEFUN([ACX_PTHREAD], [
+AC_REQUIRE([AC_CANONICAL_HOST])
+AC_LANG_SAVE
+AC_LANG_C
+acx_pthread_ok=no
+
+# We used to check for pthread.h first, but this fails if pthread.h
+# requires special compiler flags (e.g. on True64 or Sequent).
+# It gets checked for in the link test anyway.
+
+# First of all, check if the user has set any of the PTHREAD_LIBS,
+# etcetera environment variables, and if threads linking works using
+# them:
+if test x"$PTHREAD_LIBS$PTHREAD_CFLAGS" != x; then
+        save_CFLAGS="$CFLAGS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        save_LIBS="$LIBS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        AC_MSG_CHECKING([for pthread_join in LIBS=$PTHREAD_LIBS with CFLAGS=$PTHREAD_CFLAGS])
+        AC_TRY_LINK_FUNC(pthread_join, acx_pthread_ok=yes)
+        AC_MSG_RESULT($acx_pthread_ok)
+        if test x"$acx_pthread_ok" = xno; then
+                PTHREAD_LIBS=""
+                PTHREAD_CFLAGS=""
+        fi
+        LIBS="$save_LIBS"
+        CFLAGS="$save_CFLAGS"
+fi
+
+# We must check for the threads library under a number of different
+# names; the ordering is very important because some systems
+# (e.g. DEC) have both -lpthread and -lpthreads, where one of the
+# libraries is broken (non-POSIX).
+
+# Create a list of thread flags to try.  Items starting with a "-" are
+# C compiler flags, and other items are library names, except for "none"
+# which indicates that we try without any flags at all, and "pthread-config"
+# which is a program returning the flags for the Pth emulation library.
+
+acx_pthread_flags="pthreads none -Kthread -kthread lthread -pthread -pthreads -mthreads pthread --thread-safe -mt pthread-config pthreadGC2"
+
+# The ordering *is* (sometimes) important.  Some notes on the
+# individual items follow:
+
+# pthreads: AIX (must check this before -lpthread)
+# none: in case threads are in libc; should be tried before -Kthread and
+#       other compiler flags to prevent continual compiler warnings
+# -Kthread: Sequent (threads in libc, but -Kthread needed for pthread.h)
+# -kthread: FreeBSD kernel threads (preferred to -pthread since SMP-able)
+# lthread: LinuxThreads port on FreeBSD (also preferred to -pthread)
+# -pthread: Linux/gcc (kernel threads), BSD/gcc (userland threads)
+# -pthreads: Solaris/gcc
+# -mthreads: Mingw32/gcc, Lynx/gcc
+# -mt: Sun Workshop C (may only link SunOS threads [-lthread], but it
+#      doesn't hurt to check since this sometimes defines pthreads too;
+#      also defines -D_REENTRANT)
+# pthread: Linux, etcetera
+# --thread-safe: KAI C++
+# pthread-config: use pthread-config program (for GNU Pth library)
+
+case "${host_cpu}-${host_os}" in
+        *solaris*)
+
+        # On Solaris (at least, for some versions), libc contains stubbed
+        # (non-functional) versions of the pthreads routines, so link-based
+        # tests will erroneously succeed.  (We need to link with -pthread or
+        # -lpthread.)  (The stubs are missing pthread_cleanup_push, or rather
+        # a function called by this macro, so we could check for that, but
+        # who knows whether they'll stub that too in a future libc.)  So,
+        # we'll just look for -pthreads and -lpthread first:
+
+        acx_pthread_flags="-pthread -pthreads pthread -mt $acx_pthread_flags"
+        ;;
+esac
+
+if test x"$acx_pthread_ok" = xno; then
+for flag in $acx_pthread_flags; do
+
+        tryPTHREAD_CFLAGS=""
+        tryPTHREAD_LIBS=""
+        case $flag in
+                none)
+                AC_MSG_CHECKING([whether pthreads work without any flags])
+                ;;
+
+                -*)
+                AC_MSG_CHECKING([whether pthreads work with $flag])
+                tryPTHREAD_CFLAGS="$flag"
+                ;;
+
+                pthread-config)
+                # skip this if we already have flags defined, for PostgreSQL
+                if test x"$PTHREAD_CFLAGS" != x -o x"$PTHREAD_LIBS" != x; then continue; fi
+                AC_CHECK_PROG(acx_pthread_config, pthread-config, yes, no)
+                if test x"$acx_pthread_config" = xno; then continue; fi
+                tryPTHREAD_CFLAGS="`pthread-config --cflags`"
+                tryPTHREAD_LIBS="`pthread-config --ldflags` `pthread-config --libs`"
+                ;;
+
+                *)
+                AC_MSG_CHECKING([for the pthreads library -l$flag])
+                tryPTHREAD_LIBS="-l$flag"
+                ;;
+        esac
+
+        save_LIBS="$LIBS"
+        save_CFLAGS="$CFLAGS"
+        LIBS="$tryPTHREAD_LIBS $PTHREAD_LIBS $LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS $tryPTHREAD_CFLAGS"
+
+        # Check for various functions.  We must include pthread.h,
+        # since some functions may be macros.  (On the Sequent, we
+        # need a special flag -Kthread to make this header compile.)
+        # We check for pthread_join because it is in -lpthread on IRIX
+        # while pthread_create is in libc.  We check for pthread_attr_init
+        # due to DEC craziness with -lpthreads.  We check for
+        # pthread_cleanup_push because it is one of the few pthread
+        # functions on Solaris that doesn't have a non-functional libc stub.
+        # We try pthread_create on general principles.
+        AC_TRY_LINK([#include <pthread.h>],
+                    [pthread_t th; pthread_join(th, 0);
+                     pthread_attr_init(0); pthread_cleanup_push(0, 0);
+                     pthread_create(0,0,0,0); pthread_cleanup_pop(0); ],
+                    [acx_pthread_ok=yes], [acx_pthread_ok=no])
+
+        if test "x$acx_pthread_ok" = xyes; then
+            # Don't use options that are ignored by the compiler.
+            # We find them by checking stderror.
+            cat >conftest.$ac_ext <<_ACEOF
+int
+main (int argc, char **argv)
+{
+  (void) argc;
+  (void) argv;
+  return 0;
+}
+_ACEOF
+            rm -f conftest.$ac_objext conftest$ac_exeext
+            if test "`(eval $ac_link 2>&1 1>&5)`" = ""; then
+                # we continue with more flags because Linux needs -lpthread
+                # for libpq builds on PostgreSQL.  The test above only
+                # tests for building binaries, not shared libraries.
+                PTHREAD_LIBS=" $tryPTHREAD_LIBS $PTHREAD_LIBS"
+                PTHREAD_CFLAGS="$PTHREAD_CFLAGS $tryPTHREAD_CFLAGS"
+            else   acx_pthread_ok=no
+            fi
+        fi
+
+        LIBS="$save_LIBS"
+        CFLAGS="$save_CFLAGS"
+
+        AC_MSG_RESULT($acx_pthread_ok)
+done
+fi
+
+# Various other checks:
+if test "x$acx_pthread_ok" = xyes; then
+        save_LIBS="$LIBS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        save_CFLAGS="$CFLAGS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+
+        # Detect AIX lossage: threads are created detached by default
+        # and the JOINABLE attribute has a nonstandard name (UNDETACHED).
+        AC_MSG_CHECKING([for joinable pthread attribute])
+        AC_TRY_LINK([#include <pthread.h>],
+                    [int attr=PTHREAD_CREATE_JOINABLE;],
+                    ok=PTHREAD_CREATE_JOINABLE, ok=unknown)
+        if test x"$ok" = xunknown; then
+                AC_TRY_LINK([#include <pthread.h>],
+                            [int attr=PTHREAD_CREATE_UNDETACHED;],
+                            ok=PTHREAD_CREATE_UNDETACHED, ok=unknown)
+        fi
+        if test x"$ok" != xPTHREAD_CREATE_JOINABLE; then
+                AC_DEFINE(PTHREAD_CREATE_JOINABLE, $ok,
+                          [Define to the necessary symbol if this constant
+                           uses a non-standard name on your system.])
+        fi
+        AC_MSG_RESULT(${ok})
+        if test x"$ok" = xunknown; then
+                AC_MSG_WARN([we do not know how to create joinable pthreads])
+        fi
+
+        AC_MSG_CHECKING([if more special flags are required for pthreads])
+        flag=no
+# We always add these in PostgreSQL
+#       case "${host_cpu}-${host_os}" in
+#               *-aix* | *-freebsd* | *-darwin*) flag="-D_THREAD_SAFE";;
+#               *solaris* | *-osf* | *-hpux*) flag="-D_REENTRANT";;
+#       esac
+        AC_MSG_RESULT(${flag})
+        if test "x$flag" != xno; then
+                PTHREAD_CFLAGS="$flag $PTHREAD_CFLAGS"
+        fi
+
+        LIBS="$save_LIBS"
+        CFLAGS="$save_CFLAGS"
+
+# Supporting cc_r would require a special CC in all places that
+# use libpq, and that is ugly, so we don't do it.  Users can still
+# define their compiler as cc_r to do thread builds of everything.
+        # More AIX lossage: must compile with cc_r
+        AC_CHECK_PROG(PTHREAD_CC, cc_r, cc_r, ${CC})
+else
+        PTHREAD_CC="$CC"
+fi
+
+AC_SUBST(PTHREAD_LIBS)
+AC_SUBST(PTHREAD_CFLAGS)
+AC_SUBST(PTHREAD_CC)
+
+# Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
+if test x"$acx_pthread_ok" = xyes; then
+        ifelse([$1],,AC_DEFINE(HAVE_PTHREAD,1,[Define if you have POSIX threads libraries and header files.]),[$1])
+        :
+else
+        acx_pthread_ok=no
+        $2
+fi
+AC_LANG_RESTORE
+])dnl ACX_PTHREAD

--- a/par2cmdline.vcxproj
+++ b/par2cmdline.vcxproj
@@ -80,26 +80,19 @@
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <OpenMPSupport>true</OpenMPSupport>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <PrecompiledHeaderFile>src\libpar2internal.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalOptions Condition="'$(PlatformToolset)'=='ClangCL'">/openmp %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)par2.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)par2cmdline.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
-      <AdditionalOptions Condition="'$(PlatformToolset)'=='ClangCL'">-fopenmp %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies Condition="'$(PlatformToolset)'=='ClangCL'">$(LLVMInstallDir)\lib\libomp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <TargetMachine>MachineX86</TargetMachine>
     </Link>
-    <PostBuildEvent>
-      <Command Condition="'$(PlatformToolset)'=='ClangCL'">copy "$(LLVMInstallDir)\bin\libomp.dll" "$(OutDir)"</Command>
-      <Command Condition="'$(PlatformToolset)'!='ClangCL'">copy "$(DebugCppRuntimeFilesPath.Substring(0,$(DebugCppRuntimeFilesPath.IndexOf(';'))))\Microsoft.VC$(PlatformToolsetVersion).DebugOpenMP\vcomp140d.dll" "$(OutDir)"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -116,8 +109,6 @@
       <PrecompiledHeaderFile>src\libpar2internal.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <OpenMPSupport>true</OpenMPSupport>
-      <AdditionalOptions Condition="'$(PlatformToolset)'=='ClangCL'">/openmp %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)par2.exe</OutputFile>
@@ -125,13 +116,7 @@
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <AdditionalOptions Condition="'$(PlatformToolset)'=='ClangCL'">-fopenmp %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies Condition="'$(PlatformToolset)'=='ClangCL'">$(LLVMInstallDir)\lib\libomp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PostBuildEvent>
-      <Command Condition="'$(PlatformToolset)'=='ClangCL'">copy "$(LLVMInstallDir)\bin\libomp.dll" "$(OutDir)"</Command>
-      <Command Condition="'$(PlatformToolset)'!='ClangCL'">copy "$(CppRuntimeFilesPath.Substring(0,$(CppRuntimeFilesPath.IndexOf(';'))))\Microsoft.VC$(PlatformToolsetVersion).OpenMP\vcomp140.dll" "$(OutDir)"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\commandline.cpp" />

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -32,12 +32,7 @@ static char THIS_FILE[]=__FILE__;
 #endif
 #endif
 
-// OpenMP
-#ifdef _OPENMP
-# include <omp.h>
-#else
-# include <thread>
-#endif
+#include <thread>
 
 CommandLine::CommandLine(void)
 : filesize_cache()
@@ -46,9 +41,7 @@ CommandLine::CommandLine(void)
 , memorylimit(0)
 , basepath()
 , nthreads(0) // 0 means use default number
-#ifdef _OPENMP
 , filethreads( _FILE_THREADS ) // default from header file
-#endif
 , parfilename()
 , rawfilenames()
 , extrafiles()
@@ -113,15 +106,10 @@ void CommandLine::usage(void)
     "  -v [-v]  : Be more verbose\n"
     "  -q [-q]  : Be more quiet (-q -q gives silence)\n"
     "  -m<n>    : Memory (in MB) to use\n";
-#ifdef _OPENMP
   cout <<
-    "  -t<n>    : Number of threads used for main processing (" << omp_get_max_threads() << " detected)\n"
+    "  -t<n>    : Number of threads used for main processing (" << thread::hardware_concurrency() << " detected)\n"
     "  -T<n>    : Number of files hashed in parallel\n"
     "             (" << _FILE_THREADS << " are the default)\n";
-#else
-  cout <<
-    "  -t<n>    : Number of threads used for main processing (" << thread::hardware_concurrency() << " detected)\n";
-#endif
   cout <<
     "  --       : Treat all following arguments as filenames\n"
     "Options: (verify or repair)\n"
@@ -410,7 +398,6 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
           }
           break;
 
-#ifdef _OPENMP
         case 'T':  // Set amount of file threads
           {
             filethreads = 0;
@@ -429,7 +416,6 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
             }
           }
           break;
-#endif
 
         case 'r':  // Set the amount of redundancy required
           {

--- a/src/commandline.h
+++ b/src/commandline.h
@@ -103,9 +103,7 @@ public:
   bool                                GetSkipData(void) const    {return skipdata;}
   u64                                 GetSkipLeaway(void) const  {return skipleaway;}
   u32                          GetNumThreads(void) {return nthreads;}
-#ifdef _OPENMP
   u32                          GetFileThreads(void) {return filethreads;}
-#endif
 
 
   static bool ComputeRecoveryBlockCount(u32 *recoveryblockcount,
@@ -150,9 +148,7 @@ protected:
                                // or repairing.
   string basepath;             // the path par2 is run from
   u32 nthreads;         // Default number of threads
-#ifdef _OPENMP
   u32 filethreads;      // Number of threads for file processing
-#endif
   // NOTE: using the "-t" option to set the number of threads does not
   // end up here, but results in a direct call to "omp_set_num_threads"
 

--- a/src/commandline_test.cpp
+++ b/src/commandline_test.cpp
@@ -555,9 +555,7 @@ int test10_helper(const char *arg,
 		  const size_t memorylimit,
 		  const string &basepath,
 		  const u32 nthreads,
-#ifdef _OPENMP
 		  const u32 filethreads,
-#endif
 		  const string &parfilename,
 		  const vector<string> &extrafiles,
 		  const u64 blocksize,
@@ -622,13 +620,11 @@ int test10_helper(const char *arg,
     cout << commandline.GetNumThreads() << " != " << nthreads << endl;
     return 1;
   }
-#ifdef _OPENMP
   if (commandline.GetFileThreads() != filethreads) {
     cout << "test10 fail filethreads  arg=" << arg << endl;
     cout << commandline.GetFileThreads() << " != " << filethreads << endl;
     return 1;
   }
-#endif
   if (commandline.GetParFilename() != parfilename) {
     cout << "test10 fail parfilename  arg=" << arg << endl;
     cout << commandline.GetParFilename() << " != " << parfilename << endl;
@@ -712,9 +708,7 @@ int test10() {
   const size_t default_memorylimit = commandline_for_defaults.GetMemoryLimit();
   const string &default_basepath = commandline_for_defaults.GetBasePath();
   const u32 default_nthreads = 0;
-#ifdef _OPENMP
   const u32 default_filethreads = _FILE_THREADS;
-#endif
   string default_parfilename = default_basepath + "foo";  // ".par2" is stripped.
   vector<string> default_extrafiles;
   default_extrafiles.push_back(default_basepath + "input1.txt");
@@ -730,9 +724,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -752,9 +744,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -771,9 +761,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -790,9 +778,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -809,9 +795,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -828,9 +812,7 @@ int test10() {
 		    16*1024*1024,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -847,9 +829,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    42,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -860,7 +840,6 @@ int test10() {
     return 1;
   }
 
-#ifdef _OPENMP
   // -T option
   if (test10_helper("par2 create -T42 foo.par2 input1.txt input2.txt",
 		    default_noiselevel,
@@ -877,7 +856,6 @@ int test10() {
 		    default_recoveryblockcount)) {
     return 1;
   }
-#endif
 
   // -- option
   if (test10_helper("par2 create -- foo.par2 input1.txt input2.txt",
@@ -885,9 +863,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -902,9 +878,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_basepath + "-foo",
 		    default_extrafiles,
 		    default_blocksize,
@@ -928,9 +902,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    extrafiles,
 		    default_blocksize,
@@ -949,9 +921,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -971,9 +941,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    longestfilelen_rounded_up,
@@ -988,9 +956,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    8,
@@ -1012,9 +978,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1049,9 +1013,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1066,9 +1028,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1083,9 +1043,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1100,9 +1058,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1117,9 +1073,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1134,9 +1088,7 @@ int test10() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1166,9 +1118,7 @@ int test11_helper(const char *arg,
 		  const size_t memorylimit,
 		  const string &basepath,
 		  const u32 nthreads,
-#ifdef _OPENMP
 		  const u32 filethreads,
-#endif
 		  const string &parfilename,
 		  const vector<string> &extrafiles,
 		  const CommandLine::Version version,
@@ -1234,13 +1184,11 @@ int test11_helper(const char *arg,
     cout << commandline.GetNumThreads() << " != " << nthreads << endl;
     return 1;
   }
-#ifdef _OPENMP
   if (commandline.GetFileThreads() != filethreads) {
     cout << "test11 fail filethreads  arg=" << arg << endl;
     cout << commandline.GetFileThreads() << " != " << filethreads << endl;
     return 1;
   }
-#endif
   if (commandline.GetParFilename() != parfilename) {
     cout << "test11 fail parfilename  arg=" << arg << endl;
     cout << commandline.GetParFilename() << " != " << parfilename << endl;
@@ -1323,9 +1271,7 @@ int test11() {
   const size_t default_memorylimit = commandline_for_defaults.GetMemoryLimit();
   const string &default_basepath = commandline_for_defaults.GetBasePath();
   const u32 default_nthreads = 0;
-#ifdef _OPENMP
   const u32 default_filethreads = _FILE_THREADS;
-#endif
   string default_parfilename = "foo.par2"; // relative path, par2 is NOT stripped.
   vector<string> default_extrafiles;
   default_extrafiles.push_back(default_basepath + "input1.txt");
@@ -1339,9 +1285,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1360,9 +1304,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1377,9 +1319,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1395,9 +1335,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1413,9 +1351,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1431,9 +1367,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1449,9 +1383,7 @@ int test11() {
 		    16*1024*1024,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1467,9 +1399,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    42,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1479,7 +1409,6 @@ int test11() {
 		    default_skipleaway)) {
     return 1;
   }
-#ifdef _OPENMP
   // -T
   if (test11_helper("par2 repair -T42 foo.par2 input1.txt input2.txt",
 		    default_noiselevel,
@@ -1496,16 +1425,13 @@ int test11() {
 		    default_skipleaway)) {
     return 1;
   }
-#endif
   // --
   if (test11_helper("par2 repair -- foo.par2 input1.txt input2.txt",
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1526,9 +1452,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    "-foo.par2",
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1556,9 +1480,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    extrafiles,
 		    CommandLine::verPar2,
@@ -1578,9 +1500,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1596,9 +1516,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1614,9 +1532,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1633,9 +1549,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1661,9 +1575,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    "bar.par",
 		    default_extrafiles,
 		    CommandLine::verPar1,
@@ -1678,9 +1590,7 @@ int test11() {
 		    default_memorylimit,
 		    default_basepath,
 		    default_nthreads,
-#ifdef _OPENMP
 		    default_filethreads,
-#endif
 		    "bar.par",
 		    default_extrafiles,
 		    CommandLine::verPar1,

--- a/src/foreach_parallel.h
+++ b/src/foreach_parallel.h
@@ -1,0 +1,49 @@
+#ifndef __FOREACH_PARALLEL_H__
+#define __FOREACH_PARALLEL_H__
+
+#include <functional>
+#include <thread>
+#include <atomic>
+#include <future>
+
+template <class T>
+void foreach_parallel(const vector<T> &collection, u32 numThreads, const function<void(const T&)> &fn)
+{
+  if (numThreads == 1 || collection.size() == 1)
+  {
+    for (const auto &item : collection)
+      fn(item);
+  }
+  else if (numThreads >= collection.size()) 
+  {
+    // spawn a thread for each item
+    vector<future<void>> tasks;
+    tasks.reserve(collection.size());
+    for (const auto &item : collection)
+      tasks.push_back(async(launch::async, bind(fn, ref(item))));
+    for (auto &task : tasks)
+      task.wait();
+  }
+  else
+  {
+    atomic<unsigned> itemPos(0);
+    vector<thread> threads;
+    threads.reserve(numThreads);
+    for (unsigned thread = 0; thread < numThreads; thread++)
+    {
+      threads.emplace_back([&itemPos, &collection, &fn]()
+      {
+        while (1)
+        {
+          unsigned i = itemPos.fetch_add(1, memory_order_relaxed);
+          if (i >= collection.size()) break;
+          fn(collection.at(i));
+        }
+      });
+    }
+    for (auto &thread : threads)
+      thread.join();
+  }
+}
+
+#endif // __FOREACH_PARALLEL_H__

--- a/src/libpar2.cpp
+++ b/src/libpar2.cpp
@@ -25,9 +25,7 @@ Result par2create(std::ostream &sout,
 		  const size_t memorylimit,
 		  const string &basepath,
 		  const u32 nthreads,
-#ifdef _OPENMP
 		  const u32 filethreads,
-#endif
 		  const string &parfilename,
 		  const vector<string> &extrafiles,
 		  const u64 blocksize,
@@ -42,9 +40,7 @@ Result par2create(std::ostream &sout,
 				  memorylimit,
 				  basepath,
 				  nthreads,
-#ifdef _OPENMP
 				  filethreads,
-#endif
 				  parfilename,
 				  extrafiles,
 				  blocksize,
@@ -63,9 +59,7 @@ Result par2repair(std::ostream &sout,
 		  const size_t memorylimit,
 		  const string &basepath,
 		  const u32 nthreads,
-#ifdef _OPENMP
 		  const u32 filethreads,
-#endif
 		  const string &parfilename,
 		  const vector<string> &extrafiles,
 		  const bool dorepair,   // derived from operation
@@ -79,9 +73,7 @@ Result par2repair(std::ostream &sout,
 				   memorylimit,
 				   basepath,
 				   nthreads,
-#ifdef _OPENMP
 				   filethreads,
-#endif
 				   parfilename,
 				   extrafiles,
 				   dorepair,
@@ -98,10 +90,8 @@ Result par1repair(std::ostream &sout,
 		  const NoiseLevel noiselevel,
 		  const size_t memorylimit,
 		  // basepath is not used by Par1
-#ifdef _OPENMP
 		  const u32 nthreads,
 		  // filethreads is not used by Par1
-#endif
 		  const string &parfilename,
 		  const vector<string> &extrafiles,
 		  const bool dorepair,   // derived from operation
@@ -112,9 +102,7 @@ Result par1repair(std::ostream &sout,
 {
   Par1Repairer repairer(sout, serr, noiselevel);
   Result result = repairer.Process(memorylimit,
-#ifdef _OPENMP
 				   nthreads,
-#endif
 				   parfilename,
 				   extrafiles,
 				   dorepair,

--- a/src/libpar2.h
+++ b/src/libpar2.h
@@ -142,9 +142,7 @@ Result par2create(std::ostream &sout,
 			  const size_t memorylimit,
 			  const std::string &basepath,
 			  const u32 nthreads,
-#ifdef _OPENMP
 			  const u32 filethreads,
-#endif
 			  const std::string &parfilename,
 			  const std::vector<std::string> &extrafiles,
 			  const u64 blocksize,
@@ -161,9 +159,7 @@ Result par2repair(std::ostream &sout,
 		  const size_t memorylimit,
 		  const std::string &basepath,
 		  const u32 nthreads,
-#ifdef _OPENMP
 		  const u32 filethreads,
-#endif
 		  const std::string &parfilename,
 		  const std::vector<std::string> &extrafiles,
 		  const bool dorepair,   // derived from operation
@@ -178,10 +174,8 @@ Result par1repair(std::ostream &sout,
 		  const NoiseLevel noiselevel,
 		  const size_t memorylimit,
 		  // basepath is not used by Par1
-#ifdef _OPENMP
 		  const u32 nthreads,
 		  // filethreads is not used by Par1
-#endif
 		  const std::string &parfilename,
 		  const std::vector<std::string> &extrafiles,
 		  const bool dorepair,   // derived from operation

--- a/src/libpar2internal.h
+++ b/src/libpar2internal.h
@@ -253,10 +253,4 @@ using namespace std;
 #define DEBUG_NEW new(_NORMAL_BLOCK, THIS_FILE, __LINE__)
 #endif
 
-// OpenMP
-#ifdef _OPENMP
-# include <omp.h>
-#endif
-
-
 #endif // __PARCMDLINE_H__

--- a/src/par1repairer.cpp
+++ b/src/par1repairer.cpp
@@ -101,10 +101,8 @@ Par1Repairer::~Par1Repairer(void)
 
 Result Par1Repairer::Process(const size_t memorylimit,
 			     // basepath is not used by Par1
-#ifdef _OPENMP
 			     const u32 nthreads,
 			     // filethreads is not used by Par1
-#endif
 			     string parfilename,
 			     const vector<string> &extrafiles,
 			     const bool dorepair,   // derived from operation
@@ -113,11 +111,6 @@ Result Par1Repairer::Process(const size_t memorylimit,
 			     // skipleaway is not used by Par1
 			     )
 {
-#ifdef _OPENMP
-  // Set the number of threads
-  if (nthreads != 0)
-    omp_set_num_threads(nthreads);
-#endif
 
   // Determine the searchpath from the location of the main PAR file
   string name;

--- a/src/par1repairer.h
+++ b/src/par1repairer.h
@@ -29,10 +29,8 @@ public:
 
   Result Process(const size_t memorylimit,
 		 // basepath is not used by Par1
-#ifdef _OPENMP
 		 const u32 nthreads,
 		 // filethreads is not used by Par1
-#endif
 		 string parfilename,
 		 const vector<string> &extrafiles,
 		 const bool dorepair,   // derived from operation

--- a/src/par2cmdline.cpp
+++ b/src/par2cmdline.cpp
@@ -65,9 +65,7 @@ int main(int argc, char *argv[])
 			    commandline->GetMemoryLimit(),
 			    commandline->GetBasePath(),
 			    commandline->GetNumThreads(),
-#ifdef _OPENMP
 			    commandline->GetFileThreads(),
-#endif
 			    commandline->GetParFilename(),
 			    commandline->GetExtraFiles(),
 
@@ -91,9 +89,7 @@ int main(int argc, char *argv[])
 				  std::cerr,
 				  commandline->GetNoiseLevel(),
 				  commandline->GetMemoryLimit(),
-#ifdef _OPENMP
 				  commandline->GetNumThreads(),
-#endif
 				  commandline->GetParFilename(),
 				  commandline->GetExtraFiles(),
 				  commandline->GetOperation() == CommandLine::opRepair,
@@ -107,9 +103,7 @@ int main(int argc, char *argv[])
 				  commandline->GetMemoryLimit(),
 				  commandline->GetBasePath(),
 				  commandline->GetNumThreads(),
-#ifdef _OPENMP
 				  commandline->GetFileThreads(),
-#endif
 				  commandline->GetParFilename(),
 				  commandline->GetExtraFiles(),
 				  commandline->GetOperation() == CommandLine::opRepair,

--- a/src/par2creator.h
+++ b/src/par2creator.h
@@ -38,9 +38,7 @@ public:
   Result Process(const size_t memorylimit,
 		 const string &basepath,
 		 const u32 nthreads,
-#ifdef _OPENMP
 		 const u32 filethreads,
-#endif
 		 const string &parfilename,
 		 const vector<string> &extrafiles,
 		 const u64 blocksize,
@@ -97,9 +95,7 @@ protected:
   // Close all files.
   bool CloseFiles(void);
 
-#ifdef _OPENMP
   static u32                          GetFileThreads(void) {return filethreads;}
-#endif
 
 protected:
   std::ostream &sout; // stream for output (for commandline, this is cout)
@@ -107,9 +103,7 @@ protected:
 
   const NoiseLevel noiselevel; // How noisy we should be
 
-#ifdef _OPENMP
   static u32 filethreads;      // Number of threads for file processing
-#endif
 
   u64 blocksize;      // The size of each block.
   size_t chunksize;   // How much of each block will be processed at a
@@ -158,9 +152,7 @@ protected:
                              // in one pass, then we can defer the computation of
                              // the full file hash and block crc and hashes until
                              // the recovery data is computed.
-#ifdef _OPENMP
   u64 mttotalsize;           // Total size of files for mt-progress line
-#endif
 };
 
 #endif // __PAR2CREATOR_H__

--- a/src/par2creatorsourcefile.h
+++ b/src/par2creatorsourcefile.h
@@ -21,6 +21,9 @@
 #ifndef __PAR2CREATORSOURCEFILE_H__
 #define __PAR2CREATORSOURCEFILE_H__
 
+#include <atomic>
+#include <mutex>
+
 class DescriptionPacket;
 class VerificationPacket;
 class DiskFile;
@@ -41,11 +44,7 @@ public:
 
   // Open the source file and compute the Hashes and CRCs.
   //bool Open(NoiseLevel noiselevel, const string &extrafile, u64 blocksize, bool deferhashcomputation, string basepath);
-#ifdef _OPENMP
-  bool Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const string &extrafile, u64 blocksize, bool deferhashcomputation, string basepath, u64 totalsize, u64 &totalprogress);
-#else
-  bool Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const string &extrafile, u64 blocksize, bool deferhashcomputation, string basepath);
-#endif
+  bool Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const string &extrafile, u64 blocksize, bool deferhashcomputation, string basepath, u64 totalsize, atomic<u64> &totalprogress, mutex &output_lock);
   void Close(void);
 
   // Recover the file description and file verification packets

--- a/src/par2repairersourcefile.cpp
+++ b/src/par2repairersourcefile.cpp
@@ -46,9 +46,7 @@ Par2RepairerSourceFile::Par2RepairerSourceFile(DescriptionPacket *_descriptionpa
   targetfile = 0;
   completefile = 0;
 
-#ifdef _OPENMP
   diskfilesize = 0;
-#endif
 }
 
 Par2RepairerSourceFile::~Par2RepairerSourceFile(void)
@@ -156,9 +154,7 @@ void Par2RepairerSourceFile::SetBlockCount(u64 blocksize)
   }
 }
 
-#ifdef _OPENMP
 void Par2RepairerSourceFile::SetDiskFileSize()
 {
   diskfilesize = DiskFile::GetFileSize(targetfilename);
 }
-#endif

--- a/src/par2repairersourcefile.h
+++ b/src/par2repairersourcefile.h
@@ -87,11 +87,9 @@ public:
   // Get the first target DataBlock for the file
   vector<DataBlock>::iterator TargetBlocks(void) const {return targetblocks;}
 
-#if _OPENMP
   // Set/Get "filesize on disk" needed for mt progress line
   void SetDiskFileSize();
   u64 DiskFileSize(void) const {return diskfilesize;}
-#endif
 
 protected:
   DescriptionPacket           *descriptionpacket;   // The file description packet
@@ -108,9 +106,7 @@ protected:
   DiskFile                    *completefile;        // A complete version of the file
 
   string                       targetfilename;      // The filename of the target file
-#if _OPENMP
   u64                          diskfilesize;        // The filesize of sourcefile on disk
-#endif
 };
 
 #endif // __PAR2REPAIRERSOURCEFILE_H__


### PR DESCRIPTION
par2cmdline uses OpenMP to provide threading functionality. However, this OpenMP dependency prevents fully static Windows/macOS par2cmdline-turbo builds, and has caused some [difficulty](https://github.com/animetosho/par2cmdline-turbo/issues/3#issuecomment-1537172434) with the build process.

Since ParPar removes a key need behind OpenMP, par2cmdline-turbo's remaining use for it is for file-scan threading (`-T` option). There's a total of four instances of this, and these all follow a similar pattern.

Replacing these instances of OpenMP with a C++11 threads equivalent is relatively straightforward, and would eliminate this dependency.  
This may introduce a pthreads dependency on POSIX platforms (if OpenMP wasn't already depending on it), but there shouldn't be any issues with statically linking it.

This does affect libpar2 in a minor way, but par2cmdline-turbo wasn't strictly consistent with par2cmdline here anyway; par2cmdline's libpar2 ABI differs depending on whether OpenMP is enabled (which IMO is not a good idea).  
With this change, par2cmdline-turbo will always have a consistent ABI that's equivalent to par2cmdline with OpenMP.