### PR TITLE
Add staging directory support for repairs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - 'turbo'
+  release:
+    types: [published]
 
 jobs:
   build-check-linux:

--- a/config.h.in
+++ b/config.h.in
@@ -38,9 +38,6 @@
 /* Define to 1 if you have the `memcpy' function. */
 #undef HAVE_MEMCPY
 
-/* Define to 1 if you have the <memory.h> header file. */
-#undef HAVE_MEMORY_H
-
 /* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
 #undef HAVE_NDIR_H
 
@@ -119,7 +116,9 @@
    your system. */
 #undef PTHREAD_CREATE_JOINABLE
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 #undef STDC_HEADERS
 
 /* Version number of package */
@@ -142,11 +141,6 @@
 
 /* Forked package version */
 #undef X_VERSION
-
-/* Enable large inode numbers on Mac OS X 10.5.  */
-#ifndef _DARWIN_USE_64_BIT_INODE
-# define _DARWIN_USE_64_BIT_INODE 1
-#endif
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 #undef _FILE_OFFSET_BITS

--- a/config.h.in
+++ b/config.h.in
@@ -38,6 +38,9 @@
 /* Define to 1 if you have the `memcpy' function. */
 #undef HAVE_MEMCPY
 
+/* Define to 1 if you have the <memory.h> header file. */
+#undef HAVE_MEMORY_H
+
 /* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
 #undef HAVE_NDIR_H
 
@@ -116,9 +119,7 @@
    your system. */
 #undef PTHREAD_CREATE_JOINABLE
 
-/* Define to 1 if all of the C90 standard headers exist (not just the ones
-   required in a freestanding environment). This macro is provided for
-   backward compatibility; new code need not use it. */
+/* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS
 
 /* Version number of package */
@@ -141,6 +142,11 @@
 
 /* Forked package version */
 #undef X_VERSION
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 #undef _FILE_OFFSET_BITS

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,6 @@ AC_LANG(C++)
 dnl Checks for header files.
 AC_HEADER_DIRENT
 AC_HEADER_STDBOOL
-AC_HEADER_STDC
 AC_CHECK_HEADERS([stdio.h] [endian.h])
 AC_CHECK_HEADERS([getopt.h] [limits.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,7 @@ AC_LANG(C++)
 dnl Checks for header files.
 AC_HEADER_DIRENT
 AC_HEADER_STDBOOL
+AC_HEADER_STDC
 AC_CHECK_HEADERS([stdio.h] [endian.h])
 AC_CHECK_HEADERS([getopt.h] [limits.h])
 

--- a/man/par2.1
+++ b/man/par2.1
@@ -103,6 +103,9 @@ Skip leaway (distance +/\- from expected block position)
 .B \-B<path>
 Set the basepath to use as reference for the datafiles
 .TP
+.B \-D<path>
+Set the staging directory for damaged files (default: same directory)
+.TP
 .B \-\-
 Treat all following arguments as filenames
 .SH EXITCODES

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -117,6 +117,7 @@ void CommandLine::usage(void)
     "             when no recovery is needed\n"
     "  -N       : Data skipping (find badly mispositioned data blocks)\n"
     "  -S<n>    : Skip leaway (distance +/- from expected block position)\n"
+    "  -D<path> : Staging directory for damaged files (default: same directory)\n"
     "Options: (create)\n"
     "  -a<file> : Set the main PAR2 archive name\n"
     "  -b<n>    : Set the Block-Count\n"
@@ -806,6 +807,27 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
             else
             {
               basepath = DiskFile::GetCanonicalPathname(str.substr(2));
+            }
+          }
+          break;
+
+        case 'D': // Set the staging directory for damaged files
+          {
+            if (operation != opRepair && operation != opVerify)
+            {
+              cerr << "Cannot specify staging directory unless repairing or verifying." << endl;
+              return false;
+            }
+            string str = argv[0];
+            if (str == "-D")
+            {
+              stagingdirectory = DiskFile::GetCanonicalPathname(argv[1]);
+              argc--;
+              argv++;
+            }
+            else
+            {
+              stagingdirectory = DiskFile::GetCanonicalPathname(str.substr(2));
             }
           }
           break;

--- a/src/commandline.h
+++ b/src/commandline.h
@@ -97,6 +97,7 @@ public:
 
   string                              GetParFilename(void) const {return parfilename;}
   string                              GetBasePath(void) const    {return basepath;}
+  string                              GetStagingDirectory(void) const {return stagingdirectory;}
   const vector<string>& GetExtraFiles(void) const  {return extrafiles;}
   bool                                GetPurgeFiles(void) const  {return purgefiles;}
   bool                                GetRecursive(void) const   {return recursive;}
@@ -155,6 +156,8 @@ protected:
   string parfilename;          // The name of the PAR2 file to create, or
                                // the name of the first PAR2 file to read
                                // when verifying or repairing.
+
+  string stagingdirectory;     // The directory to store damaged files
 
   list<string> rawfilenames;   // The filenames on command-line
                                // (after expanding wildcards like '*')

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -987,6 +987,42 @@ bool DiskFile::Rename(void)
   return Rename(newname);
 }
 
+bool DiskFile::Rename(string filename, string stagingdirectory)
+{
+  // Extract the original filename without path
+  string path, name;
+  SplitFilename(this->filename, path, name);
+  
+  // Ensure staging directory ends with path separator
+  if (!stagingdirectory.empty() && stagingdirectory[stagingdirectory.length()-1] != '/' && stagingdirectory[stagingdirectory.length()-1] != '\\')
+  {
+    stagingdirectory += PATHSEP;
+  }
+  
+  // Create the new filename in the staging directory
+  char newname[_MAX_PATH+1];
+  u32 index = 0;
+  struct stat st;
+
+  do
+  {
+    int length = snprintf(newname, _MAX_PATH, "%s%s.%u", stagingdirectory.c_str(), name.c_str(), (unsigned int) ++index);
+    if (length < 0)
+    {
+      *serr << this->filename << " cannot be renamed." << endl;
+      return false;
+    }
+    else if (length > _MAX_PATH)
+    {
+      *serr << this->filename << " pathlength is more than " << _MAX_PATH << "." << endl;
+      return false;
+    }
+    newname[length] = 0;
+  } while (stat(newname, &st) == 0);
+
+  return Rename(newname);
+}
+
 #ifdef _WIN32
 string DiskFile::ErrorMessage(DWORD error)
 {

--- a/src/diskfile.h
+++ b/src/diskfile.h
@@ -94,6 +94,7 @@ public:
   // Rename the file
   bool Rename(void); // Pick a filename automatically
   bool Rename(string filename);
+  bool Rename(string filename, string stagingdirectory); // Rename to staging directory
 
   // Delete the file
   bool Delete(void);

--- a/src/libpar2.cpp
+++ b/src/libpar2.cpp
@@ -65,7 +65,8 @@ Result par2repair(std::ostream &sout,
 		  const bool dorepair,   // derived from operation
 		  const bool purgefiles,
 		  const bool skipdata,
-		  const u64 skipleaway
+		  const u64 skipleaway,
+		  const string &stagingdirectory
 		  )
 {
   Par2Repairer repairer(sout, serr, noiselevel);
@@ -79,7 +80,8 @@ Result par2repair(std::ostream &sout,
 				   dorepair,
 				   purgefiles,
 				   skipdata,
-				   skipleaway);
+				   skipleaway,
+				   stagingdirectory);
 
   return result;
 }

--- a/src/libpar2.h
+++ b/src/libpar2.h
@@ -165,7 +165,8 @@ Result par2repair(std::ostream &sout,
 		  const bool dorepair,   // derived from operation
 		  const bool purgefiles,
 		  const bool skipdata,
-		  const u64 skipleaway
+		  const u64 skipleaway,
+		  const std::string &stagingdirectory
 		  );
 
 

--- a/src/par2cmdline.cpp
+++ b/src/par2cmdline.cpp
@@ -123,7 +123,8 @@ int main(int argc, char* argv[])
 				  commandline->GetOperation() == CommandLine::opRepair,
 				  commandline->GetPurgeFiles(),
 				  commandline->GetSkipData(),
-				  commandline->GetSkipLeaway());
+				  commandline->GetSkipLeaway(),
+				  commandline->GetStagingDirectory());
               break;
 	    default:
               break;

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -21,6 +21,8 @@
 #include "libpar2internal.h"
 #include "foreach_parallel.h"
 
+#include <cstdio>  // for remove()
+
 #ifdef _MSC_VER
 #ifdef _DEBUG
 #undef THIS_FILE
@@ -92,6 +94,9 @@ Par2Repairer::Par2Repairer(std::ostream &sout, std::ostream &serr, const NoiseLe
   mttotalextrasize = 0;
   mttotalprogress.store(0, memory_order_relaxed);
   mtprocessingextrafiles = false;
+  
+  // Initialize staged files tracking
+  stagedfiles.clear();
 }
 
 Par2Repairer::~Par2Repairer(void)
@@ -131,7 +136,8 @@ Result Par2Repairer::Process(
 			     const bool dorepair,   // derived from operation
 			     const bool purgefiles,
 			     const bool _skipdata,
-			     const u64 _skipleaway
+			     const u64 _skipleaway,
+			     const string &_stagingdirectory
 			     )
 {
   filethreads = _filethreads;
@@ -144,6 +150,7 @@ Result Par2Repairer::Process(
 
   // Get filenames from the command line
   basepath = _basepath;
+  stagingdirectory = _stagingdirectory;
   std::vector<string> extrafiles = _extrafiles;
 
   // Determine the searchpath from the location of the main PAR2 file
@@ -243,6 +250,8 @@ Result Par2Repairer::Process(
         {
           // Delete all of the partly reconstructed files
           DeleteIncompleteTargetFiles();
+          // Cleanup staged files on failure
+          CleanupStagedFilesOnFailure();
           return eFileIOError;
         }
 
@@ -254,6 +263,8 @@ Result Par2Repairer::Process(
         {
           // Delete all of the partly reconstructed files
           DeleteIncompleteTargetFiles();
+          // Cleanup staged files on failure
+          CleanupStagedFilesOnFailure();
           return eMemoryError;
         }
 
@@ -261,6 +272,8 @@ Result Par2Repairer::Process(
         if (!parpar.init(chunksize, {{&parparcpu, 0, (size_t)chunksize}}))
         {
           DeleteIncompleteTargetFiles();
+          // Cleanup staged files on failure
+          CleanupStagedFilesOnFailure();
           return eLogicError;
         }
         if (nthreads != 0)
@@ -274,6 +287,8 @@ Result Par2Repairer::Process(
         if (!parparcpu.init(GF16_AUTO, inputbatch) || !parpar.setRecoverySlices(missingblockcount))
         {
           DeleteIncompleteTargetFiles();
+          // Cleanup staged files on failure
+          CleanupStagedFilesOnFailure();
           return eMemoryError;
         }
 
@@ -301,6 +316,8 @@ Result Par2Repairer::Process(
           if (!parpar.setCurrentSliceSize(blocklength))
           {
             DeleteIncompleteTargetFiles();
+            // Cleanup staged files on failure
+            CleanupStagedFilesOnFailure();
             return eMemoryError;
           }
 
@@ -309,6 +326,8 @@ Result Par2Repairer::Process(
           {
             // Delete all of the partly reconstructed files
             DeleteIncompleteTargetFiles();
+            // Cleanup staged files on failure
+            CleanupStagedFilesOnFailure();
             return eFileIOError;
           }
 
@@ -324,6 +343,8 @@ Result Par2Repairer::Process(
         {
           // Delete all of the partly reconstructed files
           DeleteIncompleteTargetFiles();
+          // Cleanup staged files on failure
+          CleanupStagedFilesOnFailure();
           return eFileIOError;
         }
       }
@@ -332,12 +353,16 @@ Result Par2Repairer::Process(
       if (completefilecount<mainpacket->RecoverableFileCount())
       {
         serr << "Repair Failed." << endl;
+        // Cleanup staged files on failure
+        CleanupStagedFilesOnFailure();
         return eRepairFailed;
       }
       else
       {
         if (noiselevel > nlSilent)
           sout << endl << "Repair complete." << endl;
+        // Cleanup staged files on success
+        CleanupStagedFilesOnSuccess();
       }
     }
     else
@@ -2193,7 +2218,34 @@ bool Par2Repairer::RenameTargetFiles(void)
       // Rename it
       diskFileMap.Remove(targetfile);
 
-      if (!targetfile->Rename())
+      // Use staging directory if available, otherwise use default behavior
+      bool rename_success;
+      if (!stagingdirectory.empty())
+      {
+        // Track the original file info before renaming
+        StagedFile staged_file;
+        staged_file.original_path = targetfile->FileName();
+        
+        // Extract original filename without path
+        string path, name;
+        DiskFile::SplitFilename(staged_file.original_path, path, name);
+        staged_file.original_name = name;
+        
+        rename_success = targetfile->Rename("", stagingdirectory);
+        
+        if (rename_success)
+        {
+          // Track the staged file for cleanup
+          staged_file.staged_path = targetfile->FileName();
+          stagedfiles.push_back(staged_file);
+        }
+      }
+      else
+      {
+        rename_success = targetfile->Rename();
+      }
+
+      if (!rename_success)
         return false;
 
       backuplist.push_back(targetfile);
@@ -2859,4 +2911,98 @@ bool Par2Repairer::RemoveParFiles(void)
   }
 
   return true;
+}
+
+// Cleanup staged files on successful repair
+bool Par2Repairer::CleanupStagedFilesOnSuccess(void)
+{
+  if (stagingdirectory.empty() || stagedfiles.empty())
+    return true;
+
+  if (noiselevel > nlSilent)
+    sout << endl << "Cleaning up staged files..." << endl;
+
+  if (noiselevel >= nlDebug)
+    sout << "[DEBUG] Found " << stagedfiles.size() << " staged files to clean up" << endl;
+
+  bool success = true;
+  for (vector<StagedFile>::iterator sf = stagedfiles.begin(); sf != stagedfiles.end(); ++sf)
+  {
+    if (noiselevel >= nlDebug)
+      sout << "[DEBUG] Deleting staged file: " << sf->staged_path << endl;
+      
+    // Delete the staged file since repair was successful
+    if (remove(sf->staged_path.c_str()) != 0)
+    {
+      if (noiselevel > nlSilent)
+        serr << "Warning: Could not delete staged file " << sf->staged_path << endl;
+      success = false;
+    }
+    else if (noiselevel > nlNoisy)
+    {
+      sout << "Deleted staged file: " << sf->staged_path << endl;
+    }
+  }
+
+  // Clear the staged files list
+  stagedfiles.clear();
+
+  return success;
+}
+
+// Cleanup staged files on failed repair
+bool Par2Repairer::CleanupStagedFilesOnFailure(void)
+{
+  if (stagingdirectory.empty() || stagedfiles.empty())
+    return true;
+
+  if (noiselevel > nlSilent)
+    sout << endl << "Restoring staged files..." << endl;
+
+  if (noiselevel >= nlDebug)
+    sout << "[DEBUG] Found " << stagedfiles.size() << " staged files to restore" << endl;
+
+  bool success = true;
+  for (vector<StagedFile>::iterator sf = stagedfiles.begin(); sf != stagedfiles.end(); ++sf)
+  {
+    if (noiselevel >= nlDebug)
+      sout << "[DEBUG] Processing staged file: " << sf->staged_path << " -> " << sf->original_path << endl;
+      
+    // Check if the original location is now occupied by a repaired file
+    if (DiskFile::FileExists(sf->original_path))
+    {
+      if (noiselevel >= nlDebug)
+        sout << "[DEBUG] Original location occupied, deleting repaired file: " << sf->original_path << endl;
+        
+      // Delete the repaired file since repair failed
+      if (remove(sf->original_path.c_str()) != 0)
+      {
+        if (noiselevel > nlSilent)
+          serr << "Warning: Could not delete repaired file " << sf->original_path << endl;
+        success = false;
+        continue;
+      }
+      else if (noiselevel > nlNoisy)
+      {
+        sout << "Deleted repaired file: " << sf->original_path << endl;
+      }
+    }
+
+    // Move the staged file back to its original location
+    if (rename(sf->staged_path.c_str(), sf->original_path.c_str()) != 0)
+    {
+      if (noiselevel > nlSilent)
+        serr << "Warning: Could not restore staged file " << sf->staged_path << " to " << sf->original_path << endl;
+      success = false;
+    }
+    else if (noiselevel > nlNoisy)
+    {
+      sout << "Restored staged file: " << sf->staged_path << " -> " << sf->original_path << endl;
+    }
+  }
+
+  // Clear the staged files list
+  stagedfiles.clear();
+
+  return success;
 }

--- a/src/par2repairer.h
+++ b/src/par2repairer.h
@@ -45,7 +45,8 @@ public:
 		 const bool dorepair,   // derived from operation
 		 const bool purgefiles,
 		 const bool skipdata,
-		 const u64 skipleaway
+		 const u64 skipleaway,
+		 const string &stagingdirectory
 		 );
 
 protected:
@@ -146,6 +147,10 @@ protected:
   bool RemoveBackupFiles(void);
   bool RemoveParFiles(void);
 
+  // Cleanup staged files
+  bool CleanupStagedFilesOnSuccess(void);
+  bool CleanupStagedFilesOnFailure(void);
+
   static u32                          GetFileThreads(void) {return filethreads;}
 
 protected:
@@ -159,6 +164,8 @@ protected:
   std::string               basepath;
 
   static u32 filethreads;      // Number of threads for file processing
+
+  string                    stagingdirectory;        // Directory for staging damaged files
 
   bool                      skipdata;                // Should we skip data whilst scanning
   u64                       skipleaway;              // The leaway +/- we should allow whilst scanning
@@ -177,6 +184,14 @@ protected:
   vector<Par2RepairerSourceFile*>      verifylist;   // Those source files that are being repaired
   vector<DiskFile*>                    backuplist;   // Those source files backups
   list<string>                         par2list;     // list of par2 files
+
+  // Track staged files for cleanup
+  struct StagedFile {
+    string original_path;    // Original file path
+    string staged_path;      // Path in staging directory
+    string original_name;    // Original filename without path
+  };
+  vector<StagedFile>                   stagedfiles;  // Files moved to staging directory
 
   u64                       blocksize;               // The block size.
   u64                       chunksize;               // How much of a block can be processed.


### PR DESCRIPTION
This adds a new flag for `par2 repair` that enables the usage of a staging directory, instead of simply renaming the file in-place. 

It is especially useful in scenarios where repairing large images would not be possible within the same partition, as is the case of golden images partitions.

E.g.

```
par2 repair -D/staging /golden/golden.img
```

Where `/staging` is predefined staging partition and/or directory, leveraged by the `-D` flag.

---
When using this flag...
* Upon successfully completing the repair, the temporary image (e.g. `/staging/golden.img.1`) is discarded. 
* In case of a repair failure, the image is restored to its original location (e.g. `/golden/golden.img`)